### PR TITLE
fix(traffic): persist counters & reset after report to avoid duplicate resets

### DIFF
--- a/web/job/stats_notify_job.go
+++ b/web/job/stats_notify_job.go
@@ -14,6 +14,7 @@ const (
 
 type StatsNotifyJob struct {
 	xrayService    service.XrayService
+	tgbotService   service.Tgbot
 	settingService service.SettingService
 	serverService  service.ServerService
 }

--- a/web/job/stats_notify_job.go
+++ b/web/job/stats_notify_job.go
@@ -14,7 +14,6 @@ const (
 
 type StatsNotifyJob struct {
 	xrayService    service.XrayService
-	tgbotService   service.Tgbot
 	settingService service.SettingService
 	serverService  service.ServerService
 }
@@ -29,11 +28,7 @@ func (j *StatsNotifyJob) Run() {
 		return
 	}
 
-	if !j.tgbotService.IsRunning() {
-		logger.Warning("StatsNotifyJob: telegram bot is not running")
-	} else {
-		j.tgbotService.SendReport()
-	}
+	j.tgbotService.SendReport()
 
 	runtime, err := j.settingService.GetTgbotRuntime()
 	if err != nil {

--- a/web/service/setting.go
+++ b/web/service/setting.go
@@ -77,6 +77,9 @@ var defaultValueMap = map[string]string{
 	"warp":                        "",
 	"externalTrafficInformEnable": "false",
 	"externalTrafficInformURI":    "",
+	"dailyBaseSent":               "0",
+	"dailyBaseRecv":               "0",
+	"lastDailyReset":              "0",
 }
 
 type SettingService struct{}
@@ -542,6 +545,46 @@ func (s *SettingService) GetExternalTrafficInformURI() (string, error) {
 
 func (s *SettingService) SetExternalTrafficInformURI(InformURI string) error {
 	return s.setString("externalTrafficInformURI", InformURI)
+}
+
+func (s *SettingService) GetDailyBaseSent() (uint64, error) {
+	str, err := s.getString("dailyBaseSent")
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(str, 10, 64)
+}
+
+func (s *SettingService) SetDailyBaseSent(value uint64) error {
+	return s.setString("dailyBaseSent", strconv.FormatUint(value, 10))
+}
+
+func (s *SettingService) GetDailyBaseRecv() (uint64, error) {
+	str, err := s.getString("dailyBaseRecv")
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(str, 10, 64)
+}
+
+func (s *SettingService) SetDailyBaseRecv(value uint64) error {
+	return s.setString("dailyBaseRecv", strconv.FormatUint(value, 10))
+}
+
+func (s *SettingService) GetLastDailyReset() (int64, error) {
+	str, err := s.getString("lastDailyReset")
+	if err != nil {
+		return 0, err
+	}
+	v, err := strconv.ParseInt(str, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return v, nil
+}
+
+func (s *SettingService) SetLastDailyReset(ts int64) error {
+	return s.setString("lastDailyReset", strconv.FormatInt(ts, 10))
 }
 
 func (s *SettingService) GetIpLimitEnable() (bool, error) {

--- a/web/web.go
+++ b/web/web.go
@@ -253,8 +253,8 @@ func (s *Server) startTask() {
 
 	// check client ips from log file every day
 	s.cron.AddJob("@daily", job.NewClearLogsJob())
-	// reset daily traffic counters at midnight
-	s.cron.AddJob("0 0 0 * * *", job.NewResetDailyTrafficJob())
+
+	resetByNotify := false
 
 	// Make a traffic condition every day, 8:30
 	var entry cron.EntryID
@@ -270,6 +270,10 @@ func (s *Server) startTask() {
 		if err != nil {
 			logger.Warning("Add NewStatsNotifyJob error", err)
 			return
+		}
+
+		if runtime == "@daily" {
+			resetByNotify = true
 		}
 
 		// check for Telegram bot callback query hash storage reset
@@ -292,6 +296,11 @@ func (s *Server) startTask() {
 		}
 	} else {
 		s.cron.Remove(entry)
+	}
+
+	if !resetByNotify {
+		// reset daily traffic counters at midnight
+		s.cron.AddJob("0 0 0 * * *", job.NewResetDailyTrafficJob())
 	}
 }
 


### PR DESCRIPTION
## Summary
- update StatsNotifyJob to reset daily traffic after sending the report
- avoid concurrent midnight resets by scheduling ResetDailyTrafficJob only when bot notifications are not daily

## Testing
- `./build-codex.sh`