### PR TITLE
Persist net traffic

### DIFF
--- a/web/job/save_net_traffic_job.go
+++ b/web/job/save_net_traffic_job.go
@@ -1,0 +1,15 @@
+package job
+
+import "x-ui/web/service"
+
+type SaveNetTrafficJob struct {
+	server service.ServerService
+}
+
+func NewSaveNetTrafficJob() *SaveNetTrafficJob {
+	return new(SaveNetTrafficJob)
+}
+
+func (j *SaveNetTrafficJob) Run() {
+	j.server.SaveNetTraffic()
+}

--- a/web/service/setting.go
+++ b/web/service/setting.go
@@ -80,6 +80,8 @@ var defaultValueMap = map[string]string{
 	"dailyBaseSent":               "0",
 	"dailyBaseRecv":               "0",
 	"lastDailyReset":              "0",
+	"netTrafficSent":              "0",
+	"netTrafficRecv":              "0",
 }
 
 type SettingService struct{}
@@ -585,6 +587,30 @@ func (s *SettingService) GetLastDailyReset() (int64, error) {
 
 func (s *SettingService) SetLastDailyReset(ts int64) error {
 	return s.setString("lastDailyReset", strconv.FormatInt(ts, 10))
+}
+
+func (s *SettingService) GetNetTrafficSent() (uint64, error) {
+	str, err := s.getString("netTrafficSent")
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(str, 10, 64)
+}
+
+func (s *SettingService) SetNetTrafficSent(value uint64) error {
+	return s.setString("netTrafficSent", strconv.FormatUint(value, 10))
+}
+
+func (s *SettingService) GetNetTrafficRecv() (uint64, error) {
+	str, err := s.getString("netTrafficRecv")
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(str, 10, 64)
+}
+
+func (s *SettingService) SetNetTrafficRecv(value uint64) error {
+	return s.setString("netTrafficRecv", strconv.FormatUint(value, 10))
 }
 
 func (s *SettingService) GetIpLimitEnable() (bool, error) {

--- a/web/web.go
+++ b/web/web.go
@@ -254,6 +254,9 @@ func (s *Server) startTask() {
 	// check client ips from log file every day
 	s.cron.AddJob("@daily", job.NewClearLogsJob())
 
+	// persist net traffic every 5 minutes
+	s.cron.AddJob("@every 5m", job.NewSaveNetTrafficJob())
+
 	resetByNotify := false
 
 	// Make a traffic condition every day, 8:30


### PR DESCRIPTION
## Summary
- store net traffic counters in the settings
- periodically save net traffic to DB
- load saved totals on start
- schedule new cron job to persist traffic every 5 minutes

## Testing
- `./build-codex.sh`