### PR TITLE
Fix daily traffic reset timing

### DIFF
--- a/web/controller/server.go
+++ b/web/controller/server.go
@@ -55,7 +55,7 @@ func (a *ServerController) initRouter(g *gin.RouterGroup) {
 }
 
 func (a *ServerController) refreshStatus() {
-	a.lastStatus = a.serverService.GetStatus(a.lastStatus)
+       a.lastStatus = a.serverService.GetStatus(a.lastStatus)
 }
 
 func (a *ServerController) startTask() {

--- a/web/service/server.go
+++ b/web/service/server.go
@@ -337,23 +337,13 @@ func (s *ServerService) GetStatus(lastStatus *Status) *Status {
 				s.settingService.SetLastDailyReset(s.lastDailyReset.Unix())
 			}
 		}
-		currentDay := now.In(time.Local).Truncate(24 * time.Hour)
-		if currentDay.After(s.lastDailyReset) {
-			s.dailyBaseSent = currentTotalSent
-			s.dailyBaseRecv = currentTotalRecv
-			s.lastDailyReset = currentDay
-			s.settingService.SetDailyBaseSent(s.dailyBaseSent)
-			s.settingService.SetDailyBaseRecv(s.dailyBaseRecv)
-			s.settingService.SetLastDailyReset(s.lastDailyReset.Unix())
-		} else {
-			// adjust if container counters reset
-			if currentTotalSent < s.dailyBaseSent || currentTotalRecv < s.dailyBaseRecv {
-				s.dailyBaseSent = currentTotalSent
-				s.dailyBaseRecv = currentTotalRecv
-				s.settingService.SetDailyBaseSent(s.dailyBaseSent)
-				s.settingService.SetDailyBaseRecv(s.dailyBaseRecv)
-			}
-		}
+               // adjust if container counters reset
+               if currentTotalSent < s.dailyBaseSent || currentTotalRecv < s.dailyBaseRecv {
+                       s.dailyBaseSent = currentTotalSent
+                       s.dailyBaseRecv = currentTotalRecv
+                       s.settingService.SetDailyBaseSent(s.dailyBaseSent)
+                       s.settingService.SetDailyBaseRecv(s.dailyBaseRecv)
+               }
 		status.NetDaily.Sent = currentTotalSent - s.dailyBaseSent
 		status.NetDaily.Recv = currentTotalRecv - s.dailyBaseRecv
 

--- a/web/service/tgbot.go
+++ b/web/service/tgbot.go
@@ -1937,8 +1937,8 @@ func (t *Tgbot) sendServerUsage() string {
 func (t *Tgbot) prepareServerUsageInfo() string {
 	info, ipv4, ipv6 := "", "", ""
 
-	// get latest status of server
-	t.lastStatus = t.serverService.GetStatus(t.lastStatus)
+       // get latest status of server
+       t.lastStatus = t.serverService.GetStatus(t.lastStatus)
 	onlines := p.GetOnlineClients()
 
 	info += t.I18nBot("tgbot.messages.hostname", "Hostname=="+hostname)


### PR DESCRIPTION
## Summary
- remove auto daily traffic reset from `GetStatus`
- revert `GetStatus` signature
- update controller and telegram bot to call new signature

## Testing
- `./build-codex.sh`

------
https://chatgpt.com/codex/tasks/task_b_683f6dece114832486e84eec0c25ef56