### PR TITLE
feat: add Happ routing setting

### DIFF
--- a/sub/sub.go
+++ b/sub/sub.go
@@ -127,11 +127,16 @@ func (s *Server) initRouter() (*gin.Engine, error) {
 		SubProfileWebPageUrl = ""
 	}
 
+	SubHappRouting, err := s.settingService.GetSubHappRouting()
+	if err != nil {
+		SubHappRouting = ""
+	}
+
 	g := engine.Group("/")
 
 	s.sub = NewSUBController(
 		g, LinksPath, JsonPath, Encrypt, ShowInfo, RemarkModel, SubUpdates,
-		SubJsonFragment, SubJsonNoises, SubJsonMux, SubJsonRules, SubTitle, SubAnnounce, SubSupportUrl, SubProfileWebPageUrl)
+		SubJsonFragment, SubJsonNoises, SubJsonMux, SubJsonRules, SubTitle, SubAnnounce, SubSupportUrl, SubProfileWebPageUrl, SubHappRouting)
 
 	return engine, nil
 }

--- a/sub/subController.go
+++ b/sub/subController.go
@@ -13,6 +13,7 @@ type SUBController struct {
 	subAnnounce          string
 	subSupportUrl        string
 	subProfileWebPageUrl string
+	subHappRouting       string
 	subPath              string
 	subJsonPath          string
 	subEncrypt           bool
@@ -38,6 +39,7 @@ func NewSUBController(
 	subAnnounce string,
 	subSupportUrl string,
 	subProfileWebPageUrl string,
+	subHappRouting string,
 ) *SUBController {
 	sub := NewSubService(showInfo, rModel)
 	a := &SUBController{
@@ -45,6 +47,7 @@ func NewSUBController(
 		subAnnounce:          subAnnounce,
 		subSupportUrl:        subSupportUrl,
 		subProfileWebPageUrl: subProfileWebPageUrl,
+		subHappRouting:       subHappRouting,
 		subPath:              subPath,
 		subJsonPath:          jsonPath,
 		subEncrypt:           encrypt,
@@ -84,6 +87,7 @@ func (a *SUBController) subs(c *gin.Context) {
 	}
 	supportUrl := a.subSupportUrl
 	profileWebPageUrl := a.subProfileWebPageUrl
+	happRouting := a.subHappRouting
 	announceText := a.subAnnounce
 	subs, header, err := a.subService.GetSubs(subId, host)
 	if err != nil || len(subs) == 0 {
@@ -103,6 +107,9 @@ func (a *SUBController) subs(c *gin.Context) {
 		}
 		if profileWebPageUrl != "" {
 			c.Writer.Header().Set("Profile-Web-Page-Url", profileWebPageUrl)
+		}
+		if happRouting != "" {
+			c.Writer.Header().Set("Routing", happRouting)
 		}
 		if announceText != "" {
 			c.Writer.Header().Set("Announce", announceText)
@@ -134,6 +141,7 @@ func (a *SUBController) subJsons(c *gin.Context) {
 	}
 	supportUrl := a.subSupportUrl
 	profileWebPageUrl := a.subProfileWebPageUrl
+	happRouting := a.subHappRouting
 	announceText := a.subAnnounce
 	jsonSub, header, err := a.subJsonService.GetJson(subId, host)
 	if err != nil || len(jsonSub) == 0 {
@@ -149,6 +157,9 @@ func (a *SUBController) subJsons(c *gin.Context) {
 		}
 		if profileWebPageUrl != "" {
 			c.Writer.Header().Set("Profile-Web-Page-Url", profileWebPageUrl)
+		}
+		if happRouting != "" {
+			c.Writer.Header().Set("Routing", happRouting)
 		}
 		if announceText != "" {
 			c.Writer.Header().Set("Announce", announceText)

--- a/web/assets/js/model/setting.js
+++ b/web/assets/js/model/setting.js
@@ -33,6 +33,7 @@ class AllSetting {
         this.subAnnounce = "";
         this.subSupportUrl = "";
         this.subProfileWebPageUrl = "";
+        this.subHappRouting = "";
         this.subListen = "";
         this.subPort = 2096;
         this.subPath = "/sub/";

--- a/web/entity/entity.go
+++ b/web/entity/entity.go
@@ -2,10 +2,10 @@ package entity
 
 import (
 	"crypto/tls"
+	"math"
 	"net"
 	"strings"
 	"time"
-	"math"
 
 	"x-ui/util/common"
 )
@@ -48,6 +48,7 @@ type AllSetting struct {
 	SubAnnounce                 string `json:"subAnnounce" form:"subAnnounce"`
 	SubSupportUrl               string `json:"subSupportUrl" form:"subSupportUrl"`
 	SubProfileWebPageUrl        string `json:"subProfileWebPageUrl" form:"subProfileWebPageUrl"`
+	SubHappRouting              string `json:"subHappRouting" form:"subHappRouting"`
 	SubListen                   string `json:"subListen" form:"subListen"`
 	SubPort                     int    `json:"subPort" form:"subPort"`
 	SubPath                     string `json:"subPath" form:"subPath"`

--- a/web/html/settings/panel/subscription/general.html
+++ b/web/html/settings/panel/subscription/general.html
@@ -37,6 +37,13 @@
             </template>
         </a-setting-list-item>
         <a-setting-list-item paddings="small">
+            <template #title>{{ i18n "pages.settings.subHappRouting"}}</template>
+            <template #description>{{ i18n "pages.settings.subHappRoutingDesc"}}</template>
+            <template #control>
+                <a-input type="text" v-model="allSetting.subHappRouting"></a-input>
+            </template>
+        </a-setting-list-item>
+        <a-setting-list-item paddings="small">
             <template #title>{{ i18n "pages.settings.subListen"}}</template>
             <template #description>{{ i18n "pages.settings.subListenDesc"}}</template>
             <template #control>

--- a/web/service/setting.go
+++ b/web/service/setting.go
@@ -57,6 +57,7 @@ var defaultValueMap = map[string]string{
 	"subAnnounce":                 "",
 	"subSupportUrl":               "",
 	"subProfileWebPageUrl":        "",
+	"subHappRouting":              "",
 	"subListen":                   "",
 	"subPort":                     "2096",
 	"subPath":                     "/sub/",
@@ -461,6 +462,10 @@ func (s *SettingService) GetSubProfileWebPageUrl() (string, error) {
 	return s.getString("subProfileWebPageUrl")
 }
 
+func (s *SettingService) GetSubHappRouting() (string, error) {
+	return s.getString("subHappRouting")
+}
+
 func (s *SettingService) GetSubListen() (string, error) {
 	return s.getString("subListen")
 }
@@ -673,6 +678,7 @@ func (s *SettingService) GetDefaultSettings(host string) (any, error) {
 		"subAnnounce":          func() (any, error) { return s.GetSubAnnounce() },
 		"subSupportUrl":        func() (any, error) { return s.GetSubSupportUrl() },
 		"subProfileWebPageUrl": func() (any, error) { return s.GetSubProfileWebPageUrl() },
+		"subHappRouting":       func() (any, error) { return s.GetSubHappRouting() },
 		"subURI":               func() (any, error) { return s.GetSubURI() },
 		"subJsonURI":           func() (any, error) { return s.GetSubJsonURI() },
 		"remarkModel":          func() (any, error) { return s.GetRemarkModel() },
@@ -696,6 +702,7 @@ func (s *SettingService) GetDefaultSettings(host string) (any, error) {
 		subAnnounce, _ := s.GetSubAnnounce()
 		subSupportUrl, _ := s.GetSubSupportUrl()
 		subProfileWebPageUrl, _ := s.GetSubProfileWebPageUrl()
+		subHappRouting, _ := s.GetSubHappRouting()
 		subPort, _ := s.GetSubPort()
 		subPath, _ := s.GetSubPath()
 		subJsonPath, _ := s.GetSubJsonPath()
@@ -733,6 +740,9 @@ func (s *SettingService) GetDefaultSettings(host string) (any, error) {
 		}
 		if result["subProfileWebPageUrl"].(string) == "" {
 			result["subProfileWebPageUrl"] = subProfileWebPageUrl
+		}
+		if result["subHappRouting"].(string) == "" {
+			result["subHappRouting"] = subHappRouting
 		}
 		if result["subJsonURI"].(string) == "" {
 			result["subJsonURI"] = subURI + subJsonPath

--- a/web/translation/translate.en_US.toml
+++ b/web/translation/translate.en_US.toml
@@ -354,6 +354,8 @@
 "subSupportUrlDesc" = "URL shown in Support-Url header"
 "subProfileWebPageUrl" = "Profile Web Page URL"
 "subProfileWebPageUrlDesc" = "URL shown in Profile-Web-Page-Url header"
+"subHappRouting" = "Happ Routing"
+"subHappRoutingDesc" = "Link to routing, for Happ client, sent in Routing header"
 "subListen" = "Listen IP"
 "subListenDesc" = "The IP address for the subscription service. (leave blank to listen on all IPs)"
 "subPort" = "Listen Port"

--- a/web/translation/translate.ru_RU.toml
+++ b/web/translation/translate.ru_RU.toml
@@ -354,6 +354,8 @@
 "subSupportUrlDesc" = "Ссылка, передаваемая в заголовке Support-Url"
 "subProfileWebPageUrl" = "Ссылка на сайт"
 "subProfileWebPageUrlDesc" = "Ссылка, передаваемая в заголовке Profile-Web-Page-Url"
+"subHappRouting" = "Happ Роутинг"
+"subHappRoutingDesc" = "Ссылка на роутинг, для клиента Happ, передаваемая в заголовке Routing"
 "subListen" = "Прослушивание IP"
 "subListenDesc" = "Оставьте пустым по умолчанию, чтобы отслеживать все IP-адреса"
 "subPort" = "Порт подписки"


### PR DESCRIPTION
## Summary
- add Happ Routing field to subscription settings UI
- store and expose Happ routing value in settings service
- include Happ Routing header in subscription responses

## Testing
- `./setup-codex.sh`
- `./build-codex.sh`