### PR TITLE
Fix disconnect time calculation in connection logs

### DIFF
--- a/web/entity/entity.go
+++ b/web/entity/entity.go
@@ -130,6 +130,10 @@ func (s *AllSetting) CheckValid() error {
 		return common.NewError("clientConnLogGap must be in the range 1-180, passed ", s.ClientConnLogGap)
 	}
 
+	if s.ClientConnLogGap <= s.ClientConnLogInterval {
+		return common.NewError("clientConnLogGap must be greater than clientConnLogInterval, passed ", s.ClientConnLogGap, " <= ", s.ClientConnLogInterval)
+	}
+
 	if !strings.HasPrefix(s.WebBasePath, "/") {
 		s.WebBasePath = "/" + s.WebBasePath
 	}


### PR DESCRIPTION
## Summary
- ensure client online sessions use the last log plus interval as disconnect time
- round duration to nearest second and skip zero-length sessions
- validate connection log gap is greater than the logging interval when saving settings