### PR TITLE
fix: remove leftover os import in util controller

### DIFF
--- a/web/controller/util.go
+++ b/web/controller/util.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"net"
 	"net/http"
-	"os"
 	"strings"
 
 	"x-ui/config"


### PR DESCRIPTION
## Summary
- drop unused `os` import from web controller util

## Testing
- `./build-codex.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b4449e061c8322985b5daf76d3e822